### PR TITLE
Open url based on OS

### DIFF
--- a/lua/telescope/_extensions/getOS.lua
+++ b/lua/telescope/_extensions/getOS.lua
@@ -1,5 +1,6 @@
 return function()
     -- ask LuaJIT first
+    -- will return "Windows", "Linux", "OSX", "BSD", "POSIX" or "Other"
     if jit then return jit.os end
 
     -- Unix, Linux variants

--- a/lua/telescope/_extensions/getOS.lua
+++ b/lua/telescope/_extensions/getOS.lua
@@ -1,0 +1,10 @@
+return function()
+    -- ask LuaJIT first
+    if jit then return jit.os end
+
+    -- Unix, Linux variants
+    local fh, _ = assert(io.popen('uname -o 2>/dev/null', 'r'))
+    if fh then return fh:read() end
+
+    return 'Windows'
+end

--- a/lua/telescope/_extensions/http.lua
+++ b/lua/telescope/_extensions/http.lua
@@ -5,8 +5,15 @@ if not ok then
 end
 
 local list = require 'telescope._extensions.http.list'
+local osname = require 'telescope._extensions.getOS'
 
-local default_opts = { open_url = 'xdg-open %s' }
+local open_url_os = {
+    ['OSX'] = { open_url = 'open %s' },
+    ['Windows'] = { open_url = 'start %s' },
+}
+
+local default_opts = open_url_os[osname()]
+if not default_opts then default_opts = { open_url = 'xdg-open %s' } end
 local opts = {}
 
 return telescope.register_extension {

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,10 @@ require('telescope').load_extension 'http'
 require('telescope').setup {
     extensions = {
         http = {
-            -- How the mozilla url is opened. By default:
-            open_url = 'xdg-open %s'
+            -- How the mozilla url is opened. By default will be configured based on OS:
+            open_url = 'xdg-open %s' -- UNIX
+            -- open_url = 'open %s' -- OSX
+            -- open_url = 'start %s' -- Windows
         }
     }
 }


### PR DESCRIPTION
Everything is in the title, the plugin will now open URL based on the OS the user is on.

Tested on:
- OSX => no issues
- WSL Ubuntu => did not open the url (epected behaviour, [potential fix](https://superuser.com/a/1368878) in this situation)

Note:
- If you prefer, we could integrate the `getOS.lua` logic directly in `http.lua`

Credits:
- @Zbizu gist [getOS.lua](https://gist.github.com/Zbizu/43df621b3cd0dc460a76f7fe5aa87f30)
- Commands to use per OS from this [stackoverflow answer](https://stackoverflow.com/a/38147878)